### PR TITLE
Pull request from Junting

### DIFF
--- a/src/qimpy/io/_checkpoint.py
+++ b/src/qimpy/io/_checkpoint.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Optional, NamedTuple, TypeVar
+from typing import Any, Optional, NamedTuple, TypeVar, Sequence
 import os
 
 import h5py
@@ -178,6 +178,15 @@ class CheckpointPath(NamedTuple):
             return cast_default(var)  # Use explicitly specified value when allowed
         else:
             raise CheckpointOverrideException(var_name)  # and raise, when not allowed
+
+    def create_dataset(
+        self, name: str, shape: Sequence[int], dtype: np.dtype, **kwargs
+    ) -> Any:
+        """Create dataset with `name` within current checkpoint path."""
+        assert self.checkpoint is not None
+        self.checkpoint.create_dataset(
+            "/".join((self.path, name)), shape, dtype, **kwargs
+        )
 
     def write(self, name: str, data: torch.Tensor) -> str:
         """Write `data` available on all processes to `name` within current path.

--- a/src/qimpy/transport/_time_evolution.py
+++ b/src/qimpy/transport/_time_evolution.py
@@ -16,6 +16,8 @@ class TimeEvolution(TreeNode):
     i_step: int  #: Current step number
     n_steps: int  #: Number of steps
     save_interval: int  #: Save results every so many steps
+    save_rho_interval: int  #: Save rho every so many steps
+    write_rho: bool  #: whether to write rho to checkpoint file
     n_collate: int  #: Collect these many save steps into a single checkpoint
     integrator: str  #: Time-step style used for integration
 
@@ -27,6 +29,8 @@ class TimeEvolution(TreeNode):
         t_max: float,
         n_collate: int,
         integrator: str = "RK2",
+        write_rho: bool = False,
+        dt_save_rho: float = 0.0,
         checkpoint_in: CheckpointPath = CheckpointPath(),
         geometry: Geometry,
     ) -> None:
@@ -52,11 +56,19 @@ class TimeEvolution(TreeNode):
             corresponding to the number of collated steps.
         integrator
             :yaml:`Integrator for time-stepping: RK2 or RK4.`
+        dt_save_rho
+            :yaml:`Time interval at which to save rho.`
         geometry
             Corresponding geometry from which maximum time step is determined
         """
         super().__init__()
-        self.t = 0.0
+        if checkpoint_in:
+            i_step_initial = checkpoint_in[0]["/geometry"].attrs["i_step"][-1]
+            t_initial = checkpoint_in[0]["/geometry"].attrs["t"][-1]
+            log.info(f"Setting initial step to {i_step_initial}, initial time to {t_initial}")
+        else:
+            i_step_initial,t_initial = 0, 0.0
+        self.t = t_initial
         dt_max = geometry.dt_max
         if dt == 0.0:
             if dt_max == 0.0:
@@ -68,9 +80,24 @@ class TimeEvolution(TreeNode):
         elif dt_max and (dt > dt_max):
             raise InvalidInputException(f"{dt = } must be smaller than {dt_max = }")
         self.dt = dt
-        self.i_step = 0
-        self.n_steps = max(1, int(np.round(t_max / self.dt)))
+        self.i_step = i_step_initial
+        self.n_steps = max(1, int(np.round(t_max/ self.dt))) + i_step_initial
         self.save_interval = max(1, int(np.round(dt_save / self.dt)))
+        self.write_rho = write_rho
+        if write_rho: 
+            if dt_save_rho > 0:
+                self.save_rho_interval = max(self.save_interval, int(np.round(dt_save_rho / self.dt)))
+                if self.save_rho_interval % self.save_interval != 0:
+                    raise InvalidInputException(
+                        "save_rho_interval should be divisible by save_interval"
+                    )
+            else:
+                self.save_rho_interval = self.save_interval * n_collate # Only save one rho in a file
+                log.info(f"rho saving interval is set to {self.save_rho_interval}")
+            if (self.n_steps // self.save_interval) * self.save_interval % self.save_rho_interval != 0:
+                log.info("The rho at the last save step will not be saved. " 
+                         "For a proper restart, please let "
+                         "the last save step also divisible by save_rho_interval.")
         self.n_collate = n_collate
         self.integrator = integrator
         if integrator not in {"RK2", "RK4"}:
@@ -98,9 +125,12 @@ class TimeEvolution(TreeNode):
         i_collate = 0
         while self.i_step <= self.n_steps:
             if self.i_step % self.save_interval == 0:
-                transport.geometry.update_stash(self.i_step, self.t)
+                update_rho = (self.write_rho and self.i_step % self.save_rho_interval == 0)
+                transport.geometry.update_stash(self.i_step, self.t, update_rho)
                 i_collate += 1
                 log.info(f"Stashed results of step {self.i_step}")
+                if update_rho:
+                    log.info(f"Stashed rho of step {self.i_step}")
                 if i_collate == self.n_collate:
                     transport.save(self.i_step)
                     i_collate = 0

--- a/src/qimpy/transport/_time_evolution.py
+++ b/src/qimpy/transport/_time_evolution.py
@@ -59,9 +59,11 @@ class TimeEvolution(TreeNode):
         if checkpoint_in:
             i_step_initial = checkpoint_in[0]["/geometry"].attrs["i_step"][-1]
             t_initial = checkpoint_in[0]["/geometry"].attrs["t"][-1]
-            log.info(f"Setting initial step to {i_step_initial}, initial time to {t_initial}")
+            log.info(
+                f"Setting initial step to {i_step_initial}, initial time to {t_initial}"
+            )
         else:
-            i_step_initial,t_initial = 0, 0.0
+            i_step_initial, t_initial = 0, 0.0
         self.t = t_initial
         dt_max = geometry.dt_max
         if dt == 0.0:
@@ -76,7 +78,7 @@ class TimeEvolution(TreeNode):
         self.dt = dt
         self.i_step_initial = i_step_initial
         self.i_step = i_step_initial
-        self.n_steps = max(1, int(np.round(t_max / self.dt))) + i_step_initial
+        self.n_steps = max(1, int(np.round(t_max / self.dt)))
         self.save_interval = max(1, int(np.round(dt_save / self.dt)))
         self.n_collate = n_collate
         self.integrator = integrator
@@ -104,7 +106,8 @@ class TimeEvolution(TreeNode):
         """Run time evolution loop, checkpointing at regular intervals."""
         i_collate = 0
         while self.i_step <= self.n_steps:
-            if self.i_step % self.save_interval == 0 and (self.i_step > self.i_step_initial or self.i_step == 0):
+            should_save = (self.i_step > self.i_step_initial) or (self.i_step == 0)
+            if self.i_step % self.save_interval == 0 and should_save:
                 transport.geometry.update_stash(self.i_step, self.t)
                 i_collate += 1
                 log.info(f"Stashed results of step {self.i_step}")

--- a/src/qimpy/transport/geometry/_geometry.py
+++ b/src/qimpy/transport/geometry/_geometry.py
@@ -128,7 +128,6 @@ class Geometry(TreeNode):
             min((patch.dt_max for patch in self.patches), default=np.inf), op=MPI.MIN
         )
         self.stash = ResultStash(len(self.patches))
-
         self.write_rho = write_rho
 
     @abstractmethod

--- a/src/qimpy/transport/geometry/_parameter_grid.py
+++ b/src/qimpy/transport/geometry/_parameter_grid.py
@@ -42,7 +42,8 @@ class ParameterGrid(Geometry):
             :yaml:`Parameter names and values to sweep along dimension 2.`
             Specification is the same as for `dimension1`.
         write_rho
-            :yaml:`Whether to write rho to checkpoint file.`
+            :yaml:`Whether to write the full density matrices to the checkpoint file.`
+            If not (default), only observables are written to the checkpoint file.
         """
         assert len(shape) == 2
         self.shape = shape

--- a/src/qimpy/transport/geometry/_parameter_grid.py
+++ b/src/qimpy/transport/geometry/_parameter_grid.py
@@ -97,7 +97,8 @@ class ParameterGrid(Geometry):
                 ]
                 for key, values in parameters.items()
             }
-            material.initialize_fields(patch.rho, parameters_sub, id(patch))
+            rho_initial = patch.rho.clone().detach() if checkpoint_in else patch.rho
+            material.initialize_fields(rho_initial, parameters_sub, id(patch))
 
     def create_values(
         self,

--- a/src/qimpy/transport/geometry/_parameter_grid.py
+++ b/src/qimpy/transport/geometry/_parameter_grid.py
@@ -23,7 +23,7 @@ class ParameterGrid(Geometry):
         shape: tuple[int, int],
         dimension1: Optional[dict[str, dict[str, list]]] = None,
         dimension2: Optional[dict[str, dict[str, list]]] = None,
-        write_rho: bool = False,
+        save_rho: bool = False,
         process_grid: ProcessGrid,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ) -> None:
@@ -41,7 +41,7 @@ class ParameterGrid(Geometry):
         dimension2
             :yaml:`Parameter names and values to sweep along dimension 2.`
             Specification is the same as for `dimension1`.
-        write_rho
+        save_rho
             :yaml:`Whether to write the full density matrices to the checkpoint file.`
             If not (default), only observables are written to the checkpoint file.
         """
@@ -67,7 +67,7 @@ class ParameterGrid(Geometry):
             grid_spacing=1,
             grid_size_max=0,
             contacts={},
-            write_rho=write_rho,
+            save_rho=save_rho,
             checkpoint_in=checkpoint_in,
         )
         self.dt_max = 0  # disable transport dt limit

--- a/src/qimpy/transport/geometry/_parameter_grid.py
+++ b/src/qimpy/transport/geometry/_parameter_grid.py
@@ -23,6 +23,7 @@ class ParameterGrid(Geometry):
         shape: tuple[int, int],
         dimension1: Optional[dict[str, dict[str, list]]] = None,
         dimension2: Optional[dict[str, dict[str, list]]] = None,
+        write_rho: bool = False,
         process_grid: ProcessGrid,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ) -> None:
@@ -40,6 +41,8 @@ class ParameterGrid(Geometry):
         dimension2
             :yaml:`Parameter names and values to sweep along dimension 2.`
             Specification is the same as for `dimension1`.
+        write_rho
+            :yaml:`Whether to write rho to checkpoint file.`
         """
         assert len(shape) == 2
         self.shape = shape
@@ -63,6 +66,8 @@ class ParameterGrid(Geometry):
             grid_spacing=1,
             grid_size_max=0,
             contacts={},
+            write_rho=write_rho,
+            checkpoint_in=checkpoint_in,
         )
         self.dt_max = 0  # disable transport dt limit
 

--- a/src/qimpy/transport/geometry/_patch.py
+++ b/src/qimpy/transport/geometry/_patch.py
@@ -48,8 +48,6 @@ class Patch:
     GHOST_L = slice(0, N_GHOST)  #: ghost indices on left/bottom
     GHOST_R = slice(-N_GHOST, None)  #: ghost indices on right/top side
 
-    rho_initial: torch.Tensor  # initial rho read from restart
-
     def __init__(
         self,
         *,

--- a/src/qimpy/transport/geometry/_patch.py
+++ b/src/qimpy/transport/geometry/_patch.py
@@ -105,7 +105,7 @@ class Patch:
         padding = 2 * Patch.N_GHOST
         self.rho_shape = (N[0], N[1], Nkbb)
         self.rho_padded_shape = (N[0] + padding, N[1] + padding, Nkbb)
-        if rho_initial is not None: # restart from checkpoint
+        if rho_initial is not None: # read from geometry, to restart
             slice0 = slice(grid_start[0], grid_stop[0])
             slice1 = slice(grid_start[1], grid_stop[1])
             self.rho = rho_initial[slice0, slice1]

--- a/src/qimpy/transport/geometry/_patch_set.py
+++ b/src/qimpy/transport/geometry/_patch_set.py
@@ -51,7 +51,8 @@ class PatchSet(Geometry):
             changing how data is divided into patches, and does not affect
             the accuracy of format of the output.
         write_rho
-            :yaml:`Whether to write rho to checkpoint file.`
+            :yaml:`Whether to write the full density matrices to the checkpoint file.`
+            If not (default), only observables are written to the checkpoint file.
         """
         super().__init__(
             material=material,

--- a/src/qimpy/transport/geometry/_patch_set.py
+++ b/src/qimpy/transport/geometry/_patch_set.py
@@ -24,6 +24,7 @@ class PatchSet(Geometry):
         grid_spacing: float,
         contacts: dict[str, dict],
         grid_size_max: int = 0,
+        write_rho: bool = False,
         process_grid: ProcessGrid,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ):
@@ -57,6 +58,7 @@ class PatchSet(Geometry):
             contacts=contacts,
             grid_size_max=grid_size_max,
             quad_set=parse_svg(svg_file, svg_unit, grid_spacing, list(contacts.keys())),
+            write_rho=write_rho,
             checkpoint_in=checkpoint_in,
         )
 

--- a/src/qimpy/transport/geometry/_patch_set.py
+++ b/src/qimpy/transport/geometry/_patch_set.py
@@ -24,7 +24,7 @@ class PatchSet(Geometry):
         grid_spacing: float,
         contacts: dict[str, dict],
         grid_size_max: int = 0,
-        write_rho: bool = False,
+        save_rho: bool = False,
         process_grid: ProcessGrid,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ):
@@ -50,7 +50,7 @@ class PatchSet(Geometry):
             Note that this only affects parallelization and performance by
             changing how data is divided into patches, and does not affect
             the accuracy of format of the output.
-        write_rho
+        save_rho
             :yaml:`Whether to write the full density matrices to the checkpoint file.`
             If not (default), only observables are written to the checkpoint file.
         """
@@ -61,7 +61,7 @@ class PatchSet(Geometry):
             contacts=contacts,
             grid_size_max=grid_size_max,
             quad_set=parse_svg(svg_file, svg_unit, grid_spacing, list(contacts.keys())),
-            write_rho=write_rho,
+            save_rho=save_rho,
             checkpoint_in=checkpoint_in,
         )
 

--- a/src/qimpy/transport/geometry/_patch_set.py
+++ b/src/qimpy/transport/geometry/_patch_set.py
@@ -50,6 +50,8 @@ class PatchSet(Geometry):
             Note that this only affects parallelization and performance by
             changing how data is divided into patches, and does not affect
             the accuracy of format of the output.
+        write_rho
+            :yaml:`Whether to write rho to checkpoint file.`
         """
         super().__init__(
             material=material,

--- a/src/qimpy/transport/geometry/_patch_set.py
+++ b/src/qimpy/transport/geometry/_patch_set.py
@@ -57,6 +57,7 @@ class PatchSet(Geometry):
             contacts=contacts,
             grid_size_max=grid_size_max,
             quad_set=parse_svg(svg_file, svg_unit, grid_spacing, list(contacts.keys())),
+            checkpoint_in=checkpoint_in,
         )
 
         # Initialize spatially-dependent fields, if any:

--- a/src/qimpy/transport/material/_fermi_circle.py
+++ b/src/qimpy/transport/material/_fermi_circle.py
@@ -115,12 +115,17 @@ class FermiCircle(Material):
         return result
 
     def get_observable_names(self) -> list[str]:
-        return ["q"]  # charge
+        return ["n", "jx", "jy"]  # density and fluxes
 
     @cache
     def get_observables(self, t: float) -> torch.Tensor:
-        Nkbb = len(self.k)  # since n_bands = 1
-        return torch.ones((1, Nkbb), device=rc.device)  # charge observable
+        return torch.cat(
+            (
+                torch.ones((1, self.nk_mine), device=rc.device),
+                self.transport_velocity.T,
+            ),
+            dim=0,
+        )
 
 
 class SpecularReflector:

--- a/src/qimpy/transport/material/ab_initio/_ab_initio.py
+++ b/src/qimpy/transport/material/ab_initio/_ab_initio.py
@@ -187,10 +187,11 @@ class AbInitio(Material):
                 
         # Control output observables
         obs_dict = {
-            "S": [["Sx", "Sy", "Sz"], self.S], 
             "J": [["Jx", "Jy", "Jz"], -self.P], 
-            "SJ": [["SJx", "SJy", "SJz"], -0.5 * (self.S @ self.P + self.P @ self.S)],
         }
+        if spinorial:
+            obs_dict["S"] = [["Sx", "Sy", "Sz"], self.S]
+            obs_dict["SJ"] = [["SJx", "SJy", "SJz"], -0.5 * (self.S @ self.P + self.P @ self.S)]
         self.observable_names = (["q"] if "q" in write_observables else []) + sum(
             [obs_dict[orb][0] for orb in write_observables if orb != "q"], []
         )

--- a/src/qimpy/transport/material/ab_initio/_light.py
+++ b/src/qimpy/transport/material/ab_initio/_light.py
@@ -127,13 +127,13 @@ class Light(TreeNode):
             self.light_matter[patch_id] = light_matter
             self.omega[patch_id] = omega
         else: # lindblad light
-            prefac = np.sqrt(np.sqrt(np.pi/8/smearing**2))
+            prefac = torch.sqrt(torch.sqrt(torch.pi/8/smearing**2))
             Nk,Nb = ab_initio.E.shape
             dE = ab_initio.E.reshape([Nk,Nb,1]) - ab_initio.E.reshape([Nk,1,Nb])
             plus = prefac * light_matter * torch.exp( - ((dE + omega) / (2*smearing)) **2 )
             minus = prefac * light_matter * torch.exp( - ((dE - omega) / (2*smearing)) **2 )
-            plus_deg = self.plus.swapaxes(-2, -1).conj()
-            minus_deg = self.minus.swapaxes(-2, -1).conj()
+            plus_deg = plus.swapaxes(-2, -1).conj()
+            minus_deg = minus.swapaxes(-2, -1).conj()
             
             self.identity_mat = torch.tile(torch.eye(Nb), (1,Nk,1,1)).to(rc.device)
             self.plus[patch_id] = plus

--- a/src/qimpy/transport/material/ab_initio/_light.py
+++ b/src/qimpy/transport/material/ab_initio/_light.py
@@ -92,10 +92,11 @@ class Light(TreeNode):
         self.coherent = coherent
 
     def initialize_fields(self, params: dict[str, torch.Tensor], patch_id: int) -> None:
+        self.constant_params = dict()
         pass  # TODO
 
     def rho_dot(self, rho: torch.Tensor, t: float, patch_id: int) -> torch.Tensor:
-        prefac = -0.5j * np.exp(1j * self.omega * t)  # with Louiville, symmetrization
+        prefac = -0.5j * np.exp(-1j * self.omega * t)  # with Louiville, symmetrization
         if self.sigma:
             prefac *= np.exp(-((t - self.t0) ** 2) / (2 * self.sigma**2)) / np.sqrt(
                 np.sqrt(np.pi) * self.sigma

--- a/src/qimpy/transport/material/ab_initio/_light.py
+++ b/src/qimpy/transport/material/ab_initio/_light.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from qimpy import rc, TreeNode
 from qimpy.io import CheckpointPath, InvalidInputException
+from qimpy.profiler import stopwatch
 from qimpy.transport import material
 
 
@@ -34,6 +35,7 @@ class Light(TreeNode):
         omega: float,
         t0: float = 0.0,
         sigma: float = 0.0,
+        smearing: float = 0.001,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ) -> None:
         """
@@ -58,6 +60,8 @@ class Light(TreeNode):
             :yaml:`Center of Gaussian pulse, used only if sigma is non-zero.`
         sigma
             :yaml:`Time width of Gaussian pulse, if non-zero.`
+        smearing
+            :yaml:`Width of Gaussian function to represent delta function.`
         """
         super().__init__()
         self.coherent = coherent
@@ -68,43 +72,101 @@ class Light(TreeNode):
         if (A0 is None) == (E0 is None):
             raise InvalidInputException("Exactly one of A0 and E0 must be specified")
         if A0 is not None:
-            self.A0 = torch.tensor(A0, device=rc.device)
+            A0 = torch.tensor(A0, device=rc.device)
         elif E0 is not None:
-            self.A0 = torch.tensor(E0, device=rc.device) / omega
-        if self.A0.shape[-1] == 2:  # handle complex tensors
-            self.A0 = torch.view_as_complex(self.A0)
+            A0 = torch.tensor(E0, device=rc.device) / omega
+        if A0.shape[-1] == 2:  # handle complex tensors
+            A0 = torch.view_as_complex(A0)
         else:
-            self.A0 = self.A0.to(torch.complex128)
-        self.E0 = self.A0 * omega
+            A0 = A0.to(torch.complex128)
+            
+        self.constant_params = dict(
+            A0=A0,
+            omega=torch.tensor(omega, device=rc.device),
+            t0=torch.tensor(t0, device=rc.device),
+            sigma=torch.tensor(sigma, device=rc.device),
+            smearing=torch.tensor(smearing, device=rc.device),
+        )
+        self.t0 = {}
+        self.sigma = {}
+        if self.coherent:
+            self.light_matter = {}
+            self.omega = {}
+        else:
+            self.plus = {}
+            self.plus_deg = {}
+            self.minus = {}
+            self.minus_deg = {}
 
+    def initialize_fields(self, params: dict[str, torch.Tensor], patch_id: int) -> None:
+        self._initialize_fields(patch_id, **params)
+        
+    def _initialize_fields(
+        self,
+        patch_id: int,
+        *,
+        A0: torch.Tensor,
+        omega: torch.Tensor,
+        t0: torch.Tensor,
+        sigma: torch.Tensor,
+        smearing: torch.Tensor,
+    ) -> None:
+        ab_initio = self.ab_initio
         if self.gauge == "velocity":
-            self.A0_dot_P = torch.einsum("i, kiab -> kab", self.A0, ab_initio.P)
+            light_matter = torch.einsum("i, kiab -> kab", A0, ab_initio.P)
         elif self.gauge == "length":
-            self.E0_dot_R = torch.einsum("i, kiab -> kab", self.E0, ab_initio.R)
+            light_matter = torch.einsum("i, kiab -> kab", A0 * omega, ab_initio.R)
         else:
             raise InvalidInputException(
                 "Parameter gauge should only be velocity or length"
             )
 
-        self.omega = omega
-        self.t0 = t0
-        self.sigma = sigma
-        self.coherent = coherent
+        self.t0[patch_id] = t0
+        self.sigma[patch_id] = sigma
+        if self.coherent:
+            self.light_matter[patch_id] = light_matter
+            self.omega[patch_id] = omega
+        else: # lindblad light
+            prefac = np.sqrt(np.sqrt(np.pi/8/smearing**2))
+            Nk,Nb = ab_initio.E.shape
+            dE = ab_initio.E.reshape([Nk,Nb,1]) - ab_initio.E.reshape([Nk,1,Nb])
+            plus = prefac * light_matter * torch.exp( - ((dE + omega) / (2*smearing)) **2 )
+            minus = prefac * light_matter * torch.exp( - ((dE - omega) / (2*smearing)) **2 )
+            plus_deg = self.plus.swapaxes(-2, -1).conj()
+            minus_deg = self.minus.swapaxes(-2, -1).conj()
+            
+            self.identity_mat = torch.tile(torch.eye(Nb), (1,Nk,1,1)).to(rc.device)
+            self.plus[patch_id] = plus
+            self.plus_deg[patch_id] = plus_deg
+            self.minus[patch_id] = minus
+            self.minus_deg[patch_id] = minus_deg
 
-    def initialize_fields(self, params: dict[str, torch.Tensor], patch_id: int) -> None:
-        self.constant_params = dict()
-        pass  # TODO
-
+    @stopwatch
     def rho_dot(self, rho: torch.Tensor, t: float, patch_id: int) -> torch.Tensor:
-        prefac = -0.5j * np.exp(-1j * self.omega * t)  # with Louiville, symmetrization
-        if self.sigma:
-            prefac *= np.exp(-((t - self.t0) ** 2) / (2 * self.sigma**2)) / np.sqrt(
-                np.sqrt(np.pi) * self.sigma
+        t0 = self.t0[patch_id]
+        sigma = self.sigma[patch_id]
+        if sigma > 0:
+            prefac = torch.exp(-((t - t0) ** 2) / (2 * sigma**2)) / np.sqrt(
+                        np.sqrt(np.pi) * sigma
+                    )
+        else:
+            prefac = 1.0
+        
+        if self.coherent:
+            omega = self.omega[patch_id]
+            prefac *= -0.5j * torch.exp(-1j * omega * t)  # with Louiville, symmetrization
+            interaction = prefac * self.light_matter[patch_id]
+
+            return (interaction - interaction.swapaxes(-2, -1).conj()) @ rho
+
+        else:
+            prefac = 0.5 * prefac**2
+            I_minus_rho = self.identity_mat - rho
+            return prefac * (self.commute(I_minus_rho @ self.plus[patch_id] @ rho, 
+                                          self.plus_deg[patch_id]) 
+                           + self.commute(I_minus_rho @ self.minus[patch_id] @ rho, 
+                                          self.minus_deg[patch_id])
             )
-
-        if self.gauge == "velocity":
-            light_interaction = prefac * self.A0_dot_P
-        else:  # self.gauge == "length"
-            light_interaction = prefac * self.E0_dot_R
-
-        return (light_interaction - light_interaction.swapaxes(-2, -1).conj()) @ rho
+            
+    def commute(self, A, B):
+        return A @ B - B @ A

--- a/src/qimpy/transport/material/ab_initio/_light.py
+++ b/src/qimpy/transport/material/ab_initio/_light.py
@@ -19,8 +19,8 @@ class Light(TreeNode):
     omega: float  #: light frequency
     t0: float  #: center of Gaussian pulse, if sigma is non-zero
     sigma: float  #: width of Gaussian pulse in time, if non-zero
-    A0_dot_P: torch.Tensor  #: Precomputed A0 . P matrix elements
-    E0_dot_R: torch.Tensor  #: Precomputed E0 . R matrix elements
+    smearing: float #: Width of Gaussian
+    light_matter: torch.Tensor  #: Precomputed A0 . P or E0 . R matrix elements
 
     constant_params: dict[str, torch.Tensor]  #: constant values of parameters
 

--- a/src/qimpy/transport/material/ab_initio/_relaxation_time.py
+++ b/src/qimpy/transport/material/ab_initio/_relaxation_time.py
@@ -140,7 +140,6 @@ class RelaxationTime(TreeNode):
             dbetamu = F / dF
             limit_ind = (torch.abs(dbetamu) > self.max_dbetamu) # indices that need to be limited by self.max_dbetamu
             dbetamu[limit_ind] = torch.sign(F[limit_ind]) * self.max_dbetamu
-            print(betamu.shape, dbetamu.shape)
             betamu -= dbetamu
             distribution = self.fermi_dirac(exp_betaE,betamu)
             F = torch.einsum(sum_rule, distribution).reshape(reshape) - f_total

--- a/src/qimpy/transport/material/ab_initio/_relaxation_time.py
+++ b/src/qimpy/transport/material/ab_initio/_relaxation_time.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import torch
 
-from qimpy import TreeNode
+from qimpy import TreeNode, log, rc
 from qimpy.io import CheckpointPath
 from qimpy.transport import material
 
@@ -12,6 +12,13 @@ class RelaxationTime(TreeNode):
     ab_initio: material.ab_initio.AbInitio
     tau_p: float  #: momentum relaxation time
     tau_s: float  #: spin relaxation time
+    tau_e: float  #: electron relaxation time
+    tau_h: float  #: hole relaxation time
+    max_dmu: float  #: maximum change of mu in find_mu
+    tau_recomb: float  #: recombination time
+    nv: int  #: number of valance bands
+    eps: float
+    only_diagonal: bool
 
     constant_params: dict[str, torch.Tensor]  #: constant values of parameters
 
@@ -21,6 +28,13 @@ class RelaxationTime(TreeNode):
         ab_initio: material.ab_initio.AbInitio,
         tau_p: float = np.inf,
         tau_s: float = np.inf,
+        tau_e: float = np.inf,
+        tau_h: float = np.inf,
+        max_dmu: float = 1e-3,
+        tau_recomb: float = np.inf,
+        nv: int = 0,
+        eps: float = 1e-12,
+        only_diagonal: boll = True,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ) -> None:
         """
@@ -32,14 +46,106 @@ class RelaxationTime(TreeNode):
             :yaml:`Momentum relaxation time.`
         tau_s
             :yaml:`Spin relaxation time.`
+        tau_e
+            :yaml:`Conduction bands relaxation time.`
+        tau_h
+            :yaml:`Valance bands relaxation time.`
+        max_dmu
+            :yaml:`Maximum mu change in Newton-Rhapson method.`
+        tau_recomb
+            :yaml:`Recombination time.`
+        nv
+            :yaml:`Number of valance bands.`
+        eps
+            :yaml:`Precision in the determination of mu_e and mu_h.`
+        only_diagonal
+            :yaml:`Whether only diagonal terms change.`
         """
         super().__init__()
         self.ab_initio = ab_initio
+        self.constant_params = dict()
         self.tau_p = tau_p
         self.tau_s = tau_s
+        self.tau_e = tau_e
+        self.tau_h = tau_h
+        self.tau_recomb = tau_recomb
+        self.nv = nv
+        if np.isfinite(tau_e):
+            log.info("Enable RTA for conduction bands.")
+            self.exp_betaEe = torch.exp(ab_initio.E[:,nv:]/ab_initio.T)
+            self.betamue0 = torch.Tensor([ab_initio.mu/ab_initio.T]).to(rc.device)
+        if np.isfinite(tau_h):
+            log.info("Enable RTA for valance bands.")
+            self.exp_betaEh = torch.exp(ab_initio.E[:,:nv]/ab_initio.T)
+            self.betamuh0 = torch.Tensor([ab_initio.mu/ab_initio.T]).to(rc.device)
+        if np.isfinite(tau_recomb):
+            log.info("Enable phenomenon recombination.")
+            self.exp_betaE = torch.exp(ab_initio.E/ab_initio.T)
+            self.betamuk0 = torch.ones([1,ab_initio.E.shape[0], 1]).to(rc.device) * ab_initio.mu/ab_initio.T
+        self.max_dbetamu = max_dmu/ab_initio.T
+        self.eps = eps
+        self.nbands = ab_initio.E.shape[-1]
+        self.only_diagonal = only_diagonal
 
     def initialize_fields(self, params: dict[str, torch.Tensor], patch_id: int) -> None:
         pass  # TODO
 
     def rho_dot(self, rho: torch.Tensor, t: float, patch_id: int) -> torch.Tensor:
-        raise NotImplementedError
+        result = torch.zeros_like(rho)
+        
+        if np.isfinite(self.tau_e):
+            fe = rho[...,range(self.nv,self.nbands),range(self.nv,self.nbands)].real
+            betamue,fe_eq = self.find_mu(
+                fe, self.exp_betaEe, self.betamue0, sum_rule="...kb -> ...", reshape=(fe.shape[0],)
+            )
+            if self.only_diagonal:
+                result[...,range(self.nv,self.nbands),range(self.nv,self.nbands)] -= (fe - fe_eq)/(2*self.tau_e) 
+            else:
+                result[...,self.nv:,self.nv:] -= (rho[...,self.nv:,self.nv:] -  torch.diag_embed(fe_eq))/(2*self.tau_e)
+            self.betamue0 = betamue
+            
+        if np.isfinite(self.tau_h):
+            fh = rho[...,range(self.nv),range(self.nv)].real
+            betamuh,fh_eq = self.find_mu(
+                fh, self.exp_betaEh, self.betamuh0, sum_rule="...kb -> ...", reshape=(fh.shape[0],)
+            )
+            if self.only_diagonal:
+                result[...,range(self.nv),range(self.nv)] -= (fh - fh_eq)/(2*self.tau_h) 
+            else:
+                result[...,:self.nv,:self.nv] -= (rho[...,:self.nv,:self.nv] -  torch.diag_embed(fh_eq))/(2*self.tau_h)
+                if np.isfinite(self.tau_e):
+                    tau_comb = np.sqrt(self.tau_e*self.tau_h)
+                    result[...,self.nv:,:self.nv] -= rho[...,self.nv:,:self.nv]/(2*tau_comb)
+                    result[...,:self.nv,self.nv:] -= rho[...,:self.nv,self.nv:]/(2*tau_comb)
+            self.betamuh0 = betamuh
+            
+        if np.isfinite(self.tau_recomb):
+            fk = torch.einsum("...bb -> ...b",rho).real
+            betamuk,fk_eq = self.find_mu(
+                fk, self.exp_betaE, self.betamuk0, sum_rule="...kb -> ...k", reshape=fk.shape[:-1]+(1,)
+            )
+            result -= (rho -  torch.diag_embed(fk_eq))/(2*self.tau_recomb)
+            self.betamuk0 = betamuk
+
+        return result
+    
+    def find_mu(self, f: torch.Tensor, exp_betaE: torch.Tensor, betamu0: torch.Tensor, sum_rule: str, reshape: tuple = (1,)) -> tuple[float, torch.Tensor]:
+        f_total = torch.einsum(sum_rule, f).reshape(reshape)
+        betamu = betamu0
+        distribution = self.fermi_dirac(exp_betaE,betamu)
+        F = torch.einsum(sum_rule, distribution).reshape(reshape) - f_total
+        while torch.max(torch.abs(F)) > self.eps:
+            exp_beta_Emu = exp_betaE/torch.exp(betamu)
+            dF = torch.einsum(sum_rule, exp_beta_Emu/(exp_beta_Emu + 1)**2).reshape(reshape)
+            dbetamu = F / dF
+            limit_ind = (torch.abs(dbetamu) > self.max_dbetamu) # indices that need to be limited by self.max_dbetamu
+            dbetamu[limit_ind] = torch.sign(F[limit_ind]) * self.max_dbetamu
+            print(betamu.shape, dbetamu.shape)
+            betamu -= dbetamu
+            distribution = self.fermi_dirac(exp_betaE,betamu)
+            F = torch.einsum(sum_rule, distribution).reshape(reshape) - f_total
+        return betamu, distribution
+    
+    def fermi_dirac(self, exp_betaE: torch.Tensor, betamu: torch.Tensor) -> torch.Tensor:
+        expbetamu = torch.exp(betamu)
+        return 1/(exp_betaE/expbetamu + 1)

--- a/src/qimpy/transport/material/ab_initio/_relaxation_time.py
+++ b/src/qimpy/transport/material/ab_initio/_relaxation_time.py
@@ -5,6 +5,7 @@ import torch
 
 from qimpy import TreeNode, log, rc
 from qimpy.io import CheckpointPath
+from qimpy.profiler import stopwatch
 from qimpy.transport import material
 
 
@@ -14,6 +15,7 @@ class RelaxationTime(TreeNode):
     tau_s: float  #: spin relaxation time
     tau_e: float  #: electron relaxation time
     tau_h: float  #: hole relaxation time
+    tau_eh: float #: electron-hole off-diagonal relaxation
     max_dmu: float  #: maximum change of mu in find_mu
     tau_recomb: float  #: recombination time
     nv: int  #: number of valance bands
@@ -30,11 +32,12 @@ class RelaxationTime(TreeNode):
         tau_s: float = np.inf,
         tau_e: float = np.inf,
         tau_h: float = np.inf,
+        tau_eh: float = np.inf,
         max_dmu: float = 1e-3,
         tau_recomb: float = np.inf,
         nv: int = 0,
         eps: float = 1e-12,
-        only_diagonal: boll = True,
+        only_diagonal: bool = True,
         checkpoint_in: CheckpointPath = CheckpointPath(),
     ) -> None:
         """
@@ -50,6 +53,8 @@ class RelaxationTime(TreeNode):
             :yaml:`Conduction bands relaxation time.`
         tau_h
             :yaml:`Valance bands relaxation time.`
+        tau_eh
+            :yaml:`Relaxation time of conduction-valance off diagonal terms.`
         max_dmu
             :yaml:`Maximum mu change in Newton-Rhapson method.`
         tau_recomb
@@ -63,69 +68,109 @@ class RelaxationTime(TreeNode):
         """
         super().__init__()
         self.ab_initio = ab_initio
-        self.constant_params = dict()
-        self.tau_p = tau_p
-        self.tau_s = tau_s
-        self.tau_e = tau_e
-        self.tau_h = tau_h
-        self.tau_recomb = tau_recomb
+        self.constant_params = dict(
+            tau_p=torch.tensor(tau_p, device=rc.device),
+            tau_s=torch.tensor(tau_s, device=rc.device),
+            tau_e=torch.tensor(tau_e, device=rc.device),
+            tau_h=torch.tensor(tau_h, device=rc.device),
+            tau_eh=torch.tensor(tau_eh, device=rc.device),
+            tau_recomb=torch.tensor(tau_recomb, device=rc.device),
+        )
         self.nv = nv
+        self.tau_e = {}
+        self.tau_h = {}
+        self.tau_eh = {}
+        self.tau_recomb = {}
         if np.isfinite(tau_e):
             log.info("Enable RTA for conduction bands.")
-            self.exp_betaEe = torch.exp(ab_initio.E[:,nv:]/ab_initio.T)
-            self.betamue0 = torch.Tensor([ab_initio.mu/ab_initio.T]).to(rc.device)
+            self.exp_betaEe = {}
+            self.betamue0 = {}
         if np.isfinite(tau_h):
             log.info("Enable RTA for valance bands.")
-            self.exp_betaEh = torch.exp(ab_initio.E[:,:nv]/ab_initio.T)
-            self.betamuh0 = torch.Tensor([ab_initio.mu/ab_initio.T]).to(rc.device)
+            self.exp_betaEh = {}
+            self.betamuh0 = {}
+        if np.isfinite(tau_eh):
+            log.info("Enable RTA for conduction-valance off-diagonal terms.")
         if np.isfinite(tau_recomb):
             log.info("Enable phenomenon recombination.")
-            self.exp_betaE = torch.exp(ab_initio.E/ab_initio.T)
-            self.betamuk0 = torch.ones([1,ab_initio.E.shape[0], 1]).to(rc.device) * ab_initio.mu/ab_initio.T
+            self.exp_betaE = {}
+            self.betamuk0 = {}
         self.max_dbetamu = max_dmu/ab_initio.T
         self.eps = eps
         self.nbands = ab_initio.E.shape[-1]
         self.only_diagonal = only_diagonal
 
     def initialize_fields(self, params: dict[str, torch.Tensor], patch_id: int) -> None:
-        pass  # TODO
+        self._initialize_fields(patch_id, **params)
+        
+    def _initialize_fields(
+        self,
+        patch_id: int,
+        *,
+        tau_p: torch.Tensor,
+        tau_s: torch.Tensor,
+        tau_e: torch.Tensor,
+        tau_h: torch.Tensor,
+        tau_eh: torch.Tensor,
+        tau_recomb: torch.Tensor,
+    ) -> None:
+        ab_initio = self.ab_initio
+        nv = self.nv
+        betamu0 = ab_initio.mu / ab_initio.T
+        if torch.isfinite(tau_e):
+            self.tau_e[patch_id] = tau_e
+            self.exp_betaEe[patch_id] = torch.exp(ab_initio.E[:,nv:]/ab_initio.T)
+            self.betamue0[patch_id] = torch.ones([1,1]).to(rc.device) * betamu0
+        if torch.isfinite(tau_h):
+            self.tau_h[patch_id] = tau_h
+            self.exp_betaEh[patch_id] = torch.exp(ab_initio.E[:,:nv]/ab_initio.T)
+            self.betamuh0[patch_id] = torch.ones([1,1]).to(rc.device) * betamu0
+        if torch.isfinite(tau_eh):
+            self.tau_eh[patch_id] = tau_eh
+        if torch.isfinite(tau_recomb):
+            self.tau_recomb[patch_id] = tau_recomb
+            self.exp_betaE[patch_id] = torch.exp(ab_initio.E/ab_initio.T)
+            self.betamuk0[patch_id] = torch.ones([1, 1, ab_initio.E.shape[0], 1]).to(rc.device) * betamu0
 
+    @stopwatch
     def rho_dot(self, rho: torch.Tensor, t: float, patch_id: int) -> torch.Tensor:
+        # rho.shape: (x,y,k,b)
+        nv = self.nv
         result = torch.zeros_like(rho)
         
-        if np.isfinite(self.tau_e):
-            fe = rho[...,range(self.nv,self.nbands),range(self.nv,self.nbands)].real
+        if patch_id in self.tau_e:
+            nbands = self.nbands
+            fe = rho[...,range(nv,nbands),range(nv,nbands)].real
             betamue,fe_eq = self.find_mu(
-                fe, self.exp_betaEe, self.betamue0, sum_rule="...kb -> ...", reshape=(fe.shape[0],)
+                fe, self.exp_betaEe[patch_id], self.betamue0[patch_id], sum_rule="...kb -> ...", reshape=fe.shape[:-2]
             )
             if self.only_diagonal:
-                result[...,range(self.nv,self.nbands),range(self.nv,self.nbands)] -= (fe - fe_eq)/(2*self.tau_e) 
+                result[...,range(nv,nbands),range(nv,nbands)] -= (fe - fe_eq)/(2*self.tau_e[patch_id]) 
             else:
-                result[...,self.nv:,self.nv:] -= (rho[...,self.nv:,self.nv:] -  torch.diag_embed(fe_eq))/(2*self.tau_e)
-            self.betamue0 = betamue
+                result[...,nv:,nv:] -= (rho[...,nv:,nv:] -  torch.diag_embed(fe_eq))/(2*self.tau_e[patch_id])
+            self.betamue0[patch_id] = betamue
             
-        if np.isfinite(self.tau_h):
-            fh = rho[...,range(self.nv),range(self.nv)].real
+        if patch_id in self.tau_h:
+            fh = rho[...,range(nv),range(nv)].real
             betamuh,fh_eq = self.find_mu(
-                fh, self.exp_betaEh, self.betamuh0, sum_rule="...kb -> ...", reshape=(fh.shape[0],)
+                fh, self.exp_betaEh[patch_id], self.betamuh0[patch_id], sum_rule="...kb -> ...", reshape=fh.shape[:-2]
             )
             if self.only_diagonal:
-                result[...,range(self.nv),range(self.nv)] -= (fh - fh_eq)/(2*self.tau_h) 
+                result[...,range(nv),range(nv)] -= (fh - fh_eq)/(2*self.tau_h[patch_id]) 
             else:
-                result[...,:self.nv,:self.nv] -= (rho[...,:self.nv,:self.nv] -  torch.diag_embed(fh_eq))/(2*self.tau_h)
-                if np.isfinite(self.tau_e):
-                    tau_comb = np.sqrt(self.tau_e*self.tau_h)
-                    result[...,self.nv:,:self.nv] -= rho[...,self.nv:,:self.nv]/(2*tau_comb)
-                    result[...,:self.nv,self.nv:] -= rho[...,:self.nv,self.nv:]/(2*tau_comb)
-            self.betamuh0 = betamuh
+                result[...,:nv,:nv] -= (rho[...,:nv,:nv] -  torch.diag_embed(fh_eq))/(2*self.tau_h[patch_id])
+            self.betamuh0[patch_id] = betamuh
             
-        if np.isfinite(self.tau_recomb):
+        if patch_id in self.tau_eh:
+            result[...,nv:,:nv] -= rho[...,nv:,:nv]/self.tau_eh[patch_id] # + h.c later
+            
+        if patch_id in self.tau_recomb:
             fk = torch.einsum("...bb -> ...b",rho).real
             betamuk,fk_eq = self.find_mu(
-                fk, self.exp_betaE, self.betamuk0, sum_rule="...kb -> ...k", reshape=fk.shape[:-1]+(1,)
+                fk, self.exp_betaE[patch_id], self.betamuk0[patch_id], sum_rule="...kb -> ...k", reshape=fk.shape[:-1]+(1,)
             )
-            result -= (rho -  torch.diag_embed(fk_eq))/(2*self.tau_recomb)
-            self.betamuk0 = betamuk
+            result -= (rho -  torch.diag_embed(fk_eq))/(2*self.tau_recomb[patch_id])
+            self.betamuk0[patch_id] = betamuk
 
         return result
     


### PR DESCRIPTION
Major changes:

1. _time_evolution: 
    Enabling restart from checkpoint: reading i_step_initial and t_initial
    Make a separate output at i_step == 0: previously advect_ 0999, 1999, 2999, ...; now 0000, 1000, 2000, 3000... If restarting from checkpoint, initial step will not be output

2. _geometry:
    Reading rho_initial from checkpoint_in, passed from patch_set or parameter_grid, if restart. rho_initial is passed into Patch
    write_rho boolean variable to control whether to write rho, passed from patch_set or parameter_grid.
    Only write the last rho at the moment of saving checkpoint, if write_rho == True
    Writing of rho is only paralleled in real space grid, not in k grid.

3. _patch_set/_patameter_grid: 
    Passing write_rho and checkpoint_in to geometry.

4. _patch:
    Setting rho_initial which is passed from geometry, if restart.

5. _ab_initio:
    Using a list variable write_observables to control which observables will be calculated. Default is ["q", "S"] (charge, spin).
    These observables are stacked at _init_, and will be evaluated together at get_observables(t). Observables can be flexibly customized. 

6. _light:
    Using amp_mat to represent A0 dot P or E0 dot R.
    Implementing lindblad light. The delta function is replaced by Gaussian with smearing.

7. _relaxation_time:
    Quasi-equilibrium states of electrons or holes are assumed to be Fermi-Dirac distribution. 
    mu is solved from total occupation of electrons or holes. Solving of mu involves Newton-Rhapson method. 
    Whether off-diagonal elements of rho will relax can also be controlled. 
    Recombination can also be included.